### PR TITLE
完善LockTable中selectNewXID方法

### DIFF
--- a/src/main/java/top/guoziyang/mydb/backend/vm/LockTable.java
+++ b/src/main/java/top/guoziyang/mydb/backend/vm/LockTable.java
@@ -94,6 +94,7 @@ public class LockTable {
                 continue;
             } else {
                 u2x.put(uid, xid);
+                putIntoList(x2u, xid, uid);
                 Lock lo = waitLock.remove(xid);
                 waitU.remove(xid);
                 lo.unlock();


### PR DESCRIPTION
从等待队列中选择一个xid来占用uid时，还需将该uid加入xid所持有的uid队列中