### PR TITLE
DataManagerImpl的insert方法中的回页bug

### DIFF
--- a/src/main/java/top/guoziyang/mydb/backend/dm/DataManagerImpl.java
+++ b/src/main/java/top/guoziyang/mydb/backend/dm/DataManagerImpl.java
@@ -65,6 +65,7 @@ public class DataManagerImpl extends AbstractCache<DataItem> implements DataMana
         Page pg = null;
         int freeSpace = 0;
         try {
+            freeSpace = pi.freeSpace;
             pg = pc.getPage(pi.pgno);
             byte[] log = Recover.insertLog(xid, pg, raw);
             logger.log(log);


### PR DESCRIPTION
这里没有给freeSpace赋值，导致后面的“将取出的pg重新插入pIndex”的else代码段就会给原来的pi.pgno页插入大小为0的错误大小